### PR TITLE
Resolving a typo in switcher

### DIFF
--- a/MobSwitcher.sln
+++ b/MobSwitcher.sln
@@ -13,7 +13,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MobSwitcher.Windows", "src\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tst", "Tst", "{ABF49702-0384-4FE0-A37D-A0853B929013}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MobSwticher.Cli.Tests", "tst\MobSwticher.Cli.Tests\MobSwticher.Cli.Tests.csproj", "{65A3EFCD-5F83-4802-A3CA-0C7424EBDDC7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MobSwitcher.Cli.Tests", "tst\MobSwticher.Cli.Tests\MobSwitcher.Cli.Tests.csproj", "{65A3EFCD-5F83-4802-A3CA-0C7424EBDDC7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ simon> git commit --message "describe what the mob session was all about"
 - `mob reset` deletes `mob-session` and `origin/mob-session`
 
 ## How can one customize it?
-You can set several environment variables, such as `MOBSWTICHER_WipBranch` and `MOBSWTICHER_RemoteName`, that will be picked up by `mob`. See [the appsettings.json for an extensive list](https://github.com/enorfelt/MobSwitcher/blob/master/src/MobSwitcher.Cli/appsettings.json). Use `MOBSWTICHER_`as prefix.
+You can set several environment variables, such as `MOBSWITCHER_WipBranch` and `MOBSWITCHER_RemoteName`, that will be picked up by `mob`. See [the appsettings.json for an extensive list](https://github.com/enorfelt/MobSwitcher/blob/master/src/MobSwitcher.Cli/appsettings.json). Use `MOBSWITCHER_`as prefix.
 You can also set config per repository by `mob config set UsePrettyPrint true`. That will create a `.mob` folder at the root of your repository. The folder will contain the settings file.
 
 Pretty print is enabled by default. It uses the [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts) Hack font face. You need to install it and enable it in your terminal.

--- a/src/MobSwitcher.Cli/Commands/DoneCmd.cs
+++ b/src/MobSwitcher.Cli/Commands/DoneCmd.cs
@@ -1,10 +1,6 @@
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
-using MobSwitcher.Core.Services.Git;
 using MobSwitcher.Core.Services.MobSwitch;
-using MobSwitcher.Core.Services.Shell;
 
 namespace MobSwitcher.Cli.Commands 
 {

--- a/src/MobSwitcher.Cli/Commands/JoinCmd.cs
+++ b/src/MobSwitcher.Cli/Commands/JoinCmd.cs
@@ -1,10 +1,6 @@
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
-using MobSwitcher.Core.Services.Git;
 using MobSwitcher.Core.Services.MobSwitch;
-using MobSwitcher.Core.Services.Shell;
 
 namespace MobSwitcher.Cli.Commands 
 {

--- a/src/MobSwitcher.Cli/Commands/ResetCmd.cs
+++ b/src/MobSwitcher.Cli/Commands/ResetCmd.cs
@@ -1,10 +1,6 @@
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
-using MobSwitcher.Core.Services.Git;
 using MobSwitcher.Core.Services.MobSwitch;
-using MobSwitcher.Core.Services.Shell;
 
 namespace MobSwitcher.Cli.Commands 
 {

--- a/src/MobSwitcher.Cli/Commands/StatusCmd.cs
+++ b/src/MobSwitcher.Cli/Commands/StatusCmd.cs
@@ -1,10 +1,6 @@
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
-using MobSwitcher.Core.Services.Git;
 using MobSwitcher.Core.Services.MobSwitch;
-using MobSwitcher.Core.Services.Shell;
 
 namespace MobSwitcher.Cli.Commands 
 {

--- a/src/MobSwitcher.Cli/Commands/TimerCmd.cs
+++ b/src/MobSwitcher.Cli/Commands/TimerCmd.cs
@@ -1,12 +1,7 @@
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.IO;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using MobSwitcher.Core.Services;
-using MobSwitcher.Core.Services.Git;
-using MobSwitcher.Core.Services.MobSwitch;
-using MobSwitcher.Core.Services.Shell;
 
 namespace MobSwitcher.Cli.Commands
 {

--- a/src/MobSwitcher.Cli/Services/SayPrettyService.cs
+++ b/src/MobSwitcher.Cli/Services/SayPrettyService.cs
@@ -1,7 +1,6 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
 using MobSwitcher.Core.Services;
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace MobSwitcher.Cli.Services

--- a/src/MobSwitcher.Cli/Services/SayService.cs
+++ b/src/MobSwitcher.Cli/Services/SayService.cs
@@ -1,8 +1,5 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
 using MobSwitcher.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MobSwitcher.Cli.Services
 {

--- a/src/MobSwitcher.Cli/Startup.cs
+++ b/src/MobSwitcher.Cli/Startup.cs
@@ -58,6 +58,7 @@ namespace MobSwitcher.Cli
           .SetBasePath(Directory.GetCurrentDirectory())
           .AddJsonFile(AppDomain.CurrentDomain.BaseDirectory + "\\appsettings.json", optional: true, reloadOnChange: true)
           .AddEnvironmentVariables("MOBSWTICHER_")
+          .AddEnvironmentVariables("MOBSWITCHER_")
           .AddGitPath(services)
           .Build();
       services.Configure<AppSettings>(configuration);

--- a/tst/MobSwticher.Cli.Tests/DoneCmdTests.cs
+++ b/tst/MobSwticher.Cli.Tests/DoneCmdTests.cs
@@ -1,10 +1,10 @@
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using MobSwticher.Cli.Tests.Fakes;
+using MobSwitcher.Cli.Tests.Fakes;
 using Xunit;
 
-namespace MobSwticher.Cli.Tests
+namespace MobSwitcher.Cli.Tests
 {
   public class DoneCmdTests
   {

--- a/tst/MobSwticher.Cli.Tests/Fakes/FakeSayService.cs
+++ b/tst/MobSwticher.Cli.Tests/Fakes/FakeSayService.cs
@@ -1,9 +1,7 @@
-﻿using MobSwitcher.Core.Services;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using MobSwitcher.Core.Services;
 
-namespace MobSwticher.Cli.Tests.Fakes
+namespace MobSwitcher.Cli.Tests.Fakes
 {
   public class FakeSayService : ISayService
   {

--- a/tst/MobSwticher.Cli.Tests/Fakes/FakeShellCmdService.cs
+++ b/tst/MobSwticher.Cli.Tests/Fakes/FakeShellCmdService.cs
@@ -1,9 +1,7 @@
-﻿using MobSwitcher.Core.Services.Shell;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using MobSwitcher.Core.Services.Shell;
 
-namespace MobSwticher.Cli.Tests.Fakes
+namespace MobSwitcher.Cli.Tests.Fakes
 {
   public class FakeShellCmdService : IShellCmdService
   {

--- a/tst/MobSwticher.Cli.Tests/MobSwitcher.Cli.Tests.csproj
+++ b/tst/MobSwticher.Cli.Tests/MobSwitcher.Cli.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <AssemblyName>MobSwitcher.Cli.Tests</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/tst/MobSwticher.Cli.Tests/NextCmdTests.cs
+++ b/tst/MobSwticher.Cli.Tests/NextCmdTests.cs
@@ -1,11 +1,10 @@
-using FluentAssertions;
-using MobSwticher.Cli.Tests.Fakes;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
+using MobSwitcher.Cli.Tests.Fakes;
 using Xunit;
 
-namespace MobSwticher.Cli.Tests
+namespace MobSwitcher.Cli.Tests
 {
   public class NextCmdTests
   {

--- a/tst/MobSwticher.Cli.Tests/StartCmdTests.cs
+++ b/tst/MobSwticher.Cli.Tests/StartCmdTests.cs
@@ -1,10 +1,10 @@
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using MobSwticher.Cli.Tests.Fakes;
+using MobSwitcher.Cli.Tests.Fakes;
 using Xunit;
 
-namespace MobSwticher.Cli.Tests {
+namespace MobSwitcher.Cli.Tests {
   public class StartCmdTests {
     private StartupFixture fixture;
     private FakeShellCmdService fakeCmdService;

--- a/tst/MobSwticher.Cli.Tests/StartupFixture.cs
+++ b/tst/MobSwticher.Cli.Tests/StartupFixture.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using MobSwitcher.Cli;
+using MobSwitcher.Cli.Tests.Fakes;
 using MobSwitcher.Core.Services;
 using MobSwitcher.Core.Services.Git;
-using MobSwitcher.Core.Services.Shell;
-using MobSwticher.Cli.Tests.Fakes;
 
-namespace MobSwticher.Cli.Tests {
+namespace MobSwitcher.Cli.Tests {
   public class StartupFixture : Startup {
     public FakeShellCmdService FakeShellCmdService;
     public FakeSayService FakeSayService;


### PR DESCRIPTION
Still maintaining backwards compat by allowing misspelled env variables